### PR TITLE
Update for change in GPS output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You also need to install
 [GIPPtools](https://www.gfz-potsdam.de/en/section/geophysical-deep-sounding/infrastructure/geophysical-instrument-pool-potsdam-gipp/software/gipptools/)
 and add it to your `PATH`.
 
-* Version 2015.225 or newer is required.
+* Version 2016.358 or newer is required.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
   `~/.bash_profile` or `~/.bashrc`:

--- a/cube_convert.py
+++ b/cube_convert.py
@@ -274,7 +274,7 @@ if input_args.grab_gps:
     # Define function to parse columns of input file
     def converter(string):
         return string.split('=')[-1]
-    converters = {5: converter, 6: converter, 7: converter, 10: converter}
+    converters = {6: converter, 7: converter, 8: converter, 11: converter}
 
     # Loop over all raw files in input directory
     for raw_file in raw_files:


### PR DESCRIPTION
GIPPtools release 2016.358 modified the GPS output format by inserting another column. Because of this, we have to modify which columns of the GPS log file we read in.

The relevant entry from the [release history document](https://digos.eu/wp-content/uploads/2021/06/cubetools-2021.168-ReleaseHistory.pdf) is:

> Slightly modified the GPS output format (`--format=GPS`) of the `cubeinfo` utility. The reported
leap second information now clearly indicates the origin of that information. The string *gps-leap*
stands for leap second information obtained from the GPS satellite broadcasts, while *iers-leap*
indicates leap seconds as officially announced by the International Earth Rotation and
Reference Systems Service (IERS). The later are kept in an internal table.