### PR TITLE
Add flag for EarthScope-ready miniSEED export

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ python /path/to/cube_convert.py --help
 The help menu is shown below.
 ```
 usage: cube_convert.py [-h] [-v] [--grab-gps]
-                       [--bob-factor BREAKOUT_BOX_FACTOR]
+                       [--bob-factor BREAKOUT_BOX_FACTOR] [--earthscope]
                        input_dir [input_dir ...] output_dir network station
                        {01,02,03,04,AUTO} {AUTO,BDF,HDF,CDF}
 
@@ -101,13 +101,14 @@ positional arguments:
   {AUTO,BDF,HDF,CDF}    desired SEED channel code (if AUTO, determine
                         automatically using SEED convention [preferred])
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         enable verbosity for GIPPtools commands
   --grab-gps            additionally extract coordinates from digitizer GPS
   --bob-factor BREAKOUT_BOX_FACTOR
                         factor by which to divide sensitivity values (for
                         custom breakout boxes [4.5 for UAF DATA-CUBEs])
+  --earthscope          format miniSEED files for EarthScope data upload
 ```
 For example, the command
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ options:
   --bob-factor BREAKOUT_BOX_FACTOR
                         factor by which to divide sensitivity values (for
                         custom breakout boxes [4.5 for UAF DATA-CUBEs])
-  --earthscope          format miniSEED files for EarthScope data upload
+  --earthscope          format miniSEED files for EarthScope (formerly IRIS) data upload
 ```
 For example, the command
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ cube_conversion
 
 This command-line tool converts [DiGOS](https://digos.eu/) DATA-CUBE<sup>3</sup>
 files into miniSEED files of a desired length of time with specified metadata.
-Output miniSEED files are ready for IRIS upload and have units of Pa. The tool
+Output miniSEED files have units of Pa, unless the user selects to export the files in
+a form suitable for submission to EarthScope. The tool
 can differentiate between channels for 3 channel DATA-CUBE<sup>3</sup> files and
 optionally extract coordinates from the digitizer's GPS. The code only looks for
 files from digitizers defined in the `digitizer_sensor_pairs.json` file. Therefore,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cube_conversion
 This command-line tool converts [DiGOS](https://digos.eu/) DATA-CUBE<sup>3</sup>
 files into miniSEED files of a desired length of time with specified metadata.
 Output miniSEED files have units of Pa, unless the user selects to export the files in
-a form suitable for submission to EarthScope. The tool
+a form suitable for submission to EarthScope (formerly IRIS). The tool
 can differentiate between channels for 3 channel DATA-CUBE<sup>3</sup> files and
 optionally extract coordinates from the digitizer's GPS. The code only looks for
 files from digitizers defined in the `digitizer_sensor_pairs.json` file. Therefore,

--- a/cube_convert.py
+++ b/cube_convert.py
@@ -61,7 +61,7 @@ parser.add_argument('--bob-factor', default=None, type=float,
                     help='factor by which to divide sensitivity values (for '
                          'custom breakout boxes [4.5 for UAF DATA-CUBEs])')
 parser.add_argument('--earthscope', action='store_true', dest='earthscope',
-                    help='format miniSEED files for EarthScope data upload')
+                    help='format miniSEED files for EarthScope (formerly IRIS) data upload')
 input_args = parser.parse_args()
 
 # Check if input directory/ies is/are valid

--- a/cube_convert.py
+++ b/cube_convert.py
@@ -60,6 +60,8 @@ parser.add_argument('--bob-factor', default=None, type=float,
                     dest='breakout_box_factor',
                     help='factor by which to divide sensitivity values (for '
                          'custom breakout boxes [4.5 for UAF DATA-CUBEs])')
+parser.add_argument('--earthscope', action='store_true', dest='earthscope',
+                    help='format miniSEED files for EarthScope data upload')
 input_args = parser.parse_args()
 
 # Check if input directory/ies is/are valid
@@ -144,21 +146,23 @@ except KeyError:
     offset = DEFAULT_OFFSET
 print(f'    Digitizer: {digitizer} (offset = {offset} V)')
 
-# Get sensor info and sensitivity
-sensor = digitizer_sensor_pairs[digitizer]
-try:
-    sensitivity = sensitivities[sensor]
-except KeyError:
-    warnings.warn('No matching sensitivities. Using default of '
-                  f'{DEFAULT_SENSITIVITY} V/Pa.')
-    sensitivity = DEFAULT_SENSITIVITY
-print(f'       Sensor: {sensor} (sensitivity = {sensitivity} V/Pa)')
+# Get sensor info and sensitivity (EarthScope submission requires raw counts, so we skip
+# this step if the user specified `--earthscope`)
+if not input_args.earthscope:
+    sensor = digitizer_sensor_pairs[digitizer]
+    try:
+        sensitivity = sensitivities[sensor]
+    except KeyError:
+        warnings.warn('No matching sensitivities. Using default of '
+                      f'{DEFAULT_SENSITIVITY} V/Pa.')
+        sensitivity = DEFAULT_SENSITIVITY
+    print(f'       Sensor: {sensor} (sensitivity = {sensitivity} V/Pa)')
 
-# Apply breakout box correction factor if provided
-if input_args.breakout_box_factor:
-    sensitivity = sensitivity / input_args.breakout_box_factor
-    print('       Dividing sensitivity by breakout box factor of '
-          f'{input_args.breakout_box_factor}')
+    # Apply breakout box correction factor if provided
+    if input_args.breakout_box_factor:
+        sensitivity = sensitivity / input_args.breakout_box_factor
+        print('       Dividing sensitivity by breakout box factor of '
+              f'{input_args.breakout_box_factor}')
 
 print('------------------------------------------------------------------')
 print(f'Running cube2mseed on {len(raw_files)} raw file(s)...')
@@ -166,8 +170,10 @@ print('------------------------------------------------------------------')
 
 for raw_file in raw_files:
     print(os.path.basename(raw_file))
+    # Default encoding is STEIM-1 (compressed integers) but we use uncompressed here
+    # since there is a direct NumPy data type equivalent (np.int32)
     args = ['cube2mseed', '--fringe-samples=NOMINAL', '--resample=SINC', f'--output-dir={tmp_dir}',
-            '--encoding=FLOAT-64', raw_file]
+            '--encoding=INT-32', raw_file]
     if input_args.verbose:
         args.append('--verbose')
     subprocess.call(args)
@@ -263,9 +269,21 @@ while nf < len(cut_file_list):
 
     tr.stats.channel = channel_id
 
-    tr.data = tr.data * BITWEIGHT    # Convert from counts to V
-    tr.data = tr.data + offset       # Remove voltage offset
-    tr.data = tr.data / sensitivity  # Convert from V to Pa
+    # Confidence check before we (possibly) modify the data type
+    integer_dtype = np.int32
+    assert tr.data.dtype == integer_dtype
+
+    # KEY: Modifying the time series of integer counts here!
+    if input_args.earthscope:  # Keep in integer counts!
+        if input_args.breakout_box_factor:  # Still need to account for BoB factor
+            tr.data = (tr.data * input_args.breakout_box_factor).astype(integer_dtype)
+        output_encoding = 'INT32'
+    else:  # Convert all the way to Pa (float values)
+        tr.data = tr.data * BITWEIGHT    # Convert from counts to V
+        tr.data = tr.data + offset       # Remove voltage offset
+        tr.data = tr.data / sensitivity  # Convert from V to Pa
+        assert tr.data.dtype == np.float64
+        output_encoding = 'FLOAT64'
 
     if input_args.location == 'AUTO':
         if file.endswith('.pri0'):    # Channel 1
@@ -288,7 +306,7 @@ while nf < len(cut_file_list):
     t_min = np.min([t_min, tr.stats.starttime])
     t_max = np.max([t_max, tr.stats.endtime])
 
-    st.write(file, format='MSEED')
+    st.write(file, format='MSEED', encoding=output_encoding)
 
     # Define template for miniSEED renaming
     name_template = (f'{input_args.network}.{input_args.station}'


### PR DESCRIPTION
This PR adds an option, `--earthscope`, which produces miniSEED files that are ready for EarthScope upload. Namely, this means that they are in digitizer integer counts. See #1, which this PR addresses (but not completely!).

One important change is the the encoding for `cube2mseed` has been changed to `INT-32`. Previously it was `FLOAT-64`, but I don't think this makes sense for a file that is natively coming off the digitizer in counts. The default encoding for `cube2mseed` is an integer data type, so that supports this. The code now specifies an encoding when writing the final miniSEED files.

I'm not quite sure how to handle the BoB factor. Here I've just multiplied digitizer counts by this factor. Input welcome on this!