### PR TITLE
Update README.md with .zshrc shell configuration file and adding context

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and add it to your `PATH`.
 * Version 2016.358 or newer is required.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
-  `~/.bash_profile` or `~/.bashrc`:
+  `~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`:
   ```
   export PATH=$PATH:/path/to/gipptools-????.???/bin
   ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and add it to your `PATH`.
 * Version 2016.358 or newer is required.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
-  `~/.zshrc`, `~/.bash_profile`, or `~/.bashrc`:
+  `~/.zshrc` (for Z shell), `~/.bash_profile`, or `~/.bashrc` (for Bash) :
   ```
   export PATH=$PATH:/path/to/gipptools-????.???/bin
   ```


### PR DESCRIPTION
This is a really small change, but as of 2019, the default shell for MacOS is Z shell. In the README it specifies you add the PATH to your .bash_profile or .bashrc, however this does not work if your default shell is zsh. To avoid having to activate the bash shell each time you run a cube_conversion, it is simpler to add to the PATH of the default shell config file, which is now .zshrc .

I have very little knowledge about different shells and PATH configurations, so it took me some time to figure out why my cube_convert wasn't working even after adding the path to my .bash_profile and why I had to change my shell each time I wanted it to work. I think this change could just make it a bit clearer for users that may run into the problems I had.