### PR TITLE
Resolving cube_convert error with new gipptools version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You also need to install
 [GIPPtools](https://www.gfz-potsdam.de/en/section/geophysical-imaging/infrastructure/geophysical-instrument-pool-potsdam-gipp/software/gipptools/)
 and add it to your `PATH`.
 
-* Version 2016.358 or newer is required.
+* Version 2024.170 or newer is required.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
   `~/.zshrc` (for Z shell), `~/.bash_profile`, or `~/.bashrc` (for Bash) :

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ You also need to install
 [GIPPtools](https://www.gfz-potsdam.de/en/section/geophysical-imaging/infrastructure/geophysical-instrument-pool-potsdam-gipp/software/gipptools/)
 and add it to your `PATH`.
 
-* Version 2024.170 or newer is required.
+* Version 2024.170 or newer is required and we encourage the user to always use the latest version.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
   `~/.zshrc` (for Z shell), `~/.bash_profile`, or `~/.bashrc` (for Bash) :
   ```
   export PATH=$PATH:/path/to/gipptools-????.???/bin
   ```
-  Replace `????.???` with your version of GIPPtools — e.g. `2021.168` — and
+  Replace `????.???` with your version of GIPPtools — e.g. `2024.170` — and
   ensure you've provided the right path.
 
 Supplemental files


### PR DESCRIPTION
When running cube_convert.py for data recorded on 10/3/2024 I’m getting the following error:

`ERROR: The available leap second table is too old to process the file '/Users/ltscamfer/cube_conversion/data/raw/UAF-AF0/10030000.AF0'! You need an update!!!`

I believe this Error is associated with a need to update gipptools. I’m guessing trying to convert data from at least October 2024 and newer will produce this error, and cube_convert will fail. When I updated my gipptools the error was resolved.

I think a good change to the README is updating the required version to this latest GIPPtools release! 
New GIPPtools verison required is 2024.170