### PR TITLE
Update GIPPtools version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You also need to install
 [GIPPtools](https://www.gfz-potsdam.de/en/section/geophysical-imaging/infrastructure/geophysical-instrument-pool-potsdam-gipp/software/gipptools/)
 and add it to your `PATH`.
 
-* Version 2024.170 or newer is required and we encourage the user to always use the latest version.
+* Version 2024.354 or newer is required and we encourage the user to always use the latest version.
 
 * Add GIPPtools to your `PATH` by adding the following line to your
   `~/.zshrc` (for Z shell), `~/.bash_profile`, or `~/.bashrc` (for Bash) :


### PR DESCRIPTION
A previous PR introduced code that uses `cubeaux` but this command was only introduced in 2024.354 so we need to tell users this is the minimum version.